### PR TITLE
fix(react): 修复no-console规则和index冲突，增加eslint-plugin-react-hooks依赖

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hongshancapital/eslint-config-hongshan",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "main": "index.js",
   "repository": "git@github.com:hongshancapital/eslint-config-hongshan.git",
   "author": "Gao Sun",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "eslint-plugin-no-secrets": "^1.0.2",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-promise": "^6.0.0",
-    "eslint-plugin-react": "^7.35.2"
+    "eslint-plugin-react": "^7.35.2",
+    "eslint-plugin-react-hooks": "^4.6.2"
   },
   "peerDependencies": {
     "eslint": "^8.56.0",

--- a/react.js
+++ b/react.js
@@ -18,7 +18,6 @@ module.exports = {
   },
   rules: {
     // base
-    "no-console": ["error", { allow: ["warn", "error"] }],
     "max-lines": ["error", { max: 490, skipComments: true }],
     "space-before-function-paren": "off",
     "arrow-parens": ["error", "always"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -681,6 +681,11 @@ eslint-plugin-promise@^6.0.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz#269a3e2772f62875661220631bd4dafcb4083816"
   integrity sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==
 
+eslint-plugin-react-hooks@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz#c829eb06c0e6f484b3fbb85a97e57784f328c596"
+  integrity sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==
+
 eslint-plugin-react@^7.35.2:
   version "7.35.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.35.2.tgz#d32500d3ec268656d5071918bfec78cfd8b070ed"


### PR DESCRIPTION
在Lite中升级时发现2个小问题，修复一下：

0. react.js console规则覆盖了Index.js
0. react 规则还依赖了hooks插件，也要加到依赖声明中