### PR TITLE
feat: 新增 Oxlint 规则配对与 strict 档位，强制 prefer-at

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ export default defineConfig(
 
 ### Oxfmt
 
-`/oxfmt` 默认开启 import、`package.json` 和 Tailwind CSS class 排序：
+`/oxfmt` 默认开启 `package.json` 和 Tailwind CSS class 排序。import 排序（`sortImports`）默认**关闭**：CSS Modules 的样式导入顺序决定层叠优先级，后导入覆盖先导入，而 Oxfmt 的 import 排序无法对样式导入组保持源序（组内强制按字母序），自动重排会破坏层叠语义。需要排序的项目可显式开启，并自行承担样式导入顺序被重排的影响：
 
 ```ts
 // oxfmt.config.ts
@@ -493,7 +493,7 @@ import { defineConfig } from '@hongshancapital/eslint-config-hongshan/oxfmt';
 
 export default defineConfig({
   ignorePatterns: ['generated/**'],
-  sortImports: false,
+  // sortImports: true,
   // sortPackageJson: false,
   // sortTailwindcss: false,
 });

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ import { defineConfig } from '@hongshancapital/eslint-config-hongshan/oxlint';
 
 export default defineConfig({
   preset: 'frontend',
+  strict: true,
   ignorePatterns: ['generated/**'],
 });
 ```
@@ -220,7 +221,7 @@ AI Agent 应区分“配置无法加载”和“配置已生效但发现代码�
 import { defineConfig } from '@hongshancapital/eslint-config-hongshan';
 
 export default defineConfig(
-  { typescript: true },
+  { typescript: 'recommended' },
   {
     rules: {
       'no-warning-comments': 'warn',
@@ -252,9 +253,9 @@ oxlint --rules --format=json
 
 只有 runtime 中实际开启且存在 ESLint 等价实现的规则会生成新的 ESLint `off`。根级最终状态为 `off` 的规则、未加载 plugin 的规则，以及未启用 Oxlint type-aware runtime 的 type-aware 规则不会生成 `off`；override 如何收回根级 rule owner 见下文。
 
-默认启用 TypeScript ESLint 时，一个 Oxlint rule 可能关闭多个 ESLint aliases，例如：
+TypeScript ESLint 始终启用，一个 Oxlint rule 可能关闭多个 ESLint aliases，例如：
 
-- `no-unused-vars` → `no-unused-vars`、`@typescript-eslint/no-unused-vars`（`typescript !== false`）
+- `no-unused-vars` → `no-unused-vars`、`@typescript-eslint/no-unused-vars`
 - `import/no-duplicates` → `import/no-duplicates`、`import-x/no-duplicates`
 - `react/rules-of-hooks` → `react-hooks/rules-of-hooks`
 - `react/only-export-components` → `react/only-export-components`、`react-refresh/only-export-components`
@@ -355,6 +356,7 @@ import { defineConfig } from '@hongshancapital/eslint-config-hongshan/oxlint';
 
 export default defineConfig({
   preset: 'backend',
+  strict: true,
   options: {
     typeAware: true,
   },
@@ -383,6 +385,7 @@ export default defineConfig({
 - 当前不支持会改变 plugin 集合的 Oxlint overrides，也不支持外部 Oxlint JavaScript plugins；遇到 `override.plugins`、override `jsPlugins` 或非空根 `jsPlugins` 时会报错。
 - `oxc` 专属规则和未知 rule scope 没有可靠的 ESLint 对应关系，会被跳过。
 - 对 `.vue`、`.svelte` 和 `.astro`，少量规则不会派生 ESLint `off`；本包不会因此自动配置这些文件所需的 ESLint parser 或 processor。
+- `no-dupe-args`、`no-octal` 和 `no-undef` 有意保留在 ESLint：前两条在 Oxlint 中无等价实现；`no-undef` 的 globals 语义在两个 linter 间不一致（Oxlint env 按 preset 划分，ESLint 同时注入 browser 和 node globals），下沉会造成假阳性。此外 `no-undef` 在 TypeScript 文件中由 typescript-eslint recommended 额外关闭（`tsc` 已覆盖该检查），JavaScript 文件中仍由 ESLint 执行。
 
 ## Oxlint 配置参考
 
@@ -391,7 +394,9 @@ export default defineConfig({
 - `frontend`：Browser + ES2024，默认启用 React。
 - `backend`：Node.js + ES2024，默认不启用 React。
 
-默认整体开启的 category 只有 `correctness: 'error'`；此外还启用本包维护的显式规则，包括经过验证的 Nursery `import/export`。`categories`、`env` 和 `rules` 按 key 合并，用户值优先；`ignorePatterns` 和 `overrides` 追加在默认值之后。
+默认整体开启的 category 只有 `correctness: 'error'`；此外还启用本包维护的显式规则，覆盖了 `eslint:recommended` 和 `typescript-eslint` 的 recommended 层中所有在 Oxlint 有等价实现的规则，以及经过验证的 Nursery `import/export`。配对后 ESLint 只保留 Oxlint 无等价实现或语义不等价的规则（`no-dupe-args`、`no-octal`、`no-undef`）。`categories`、`env` 和 `rules` 按 key 合并，用户值优先；`ignorePatterns` 和 `overrides` 追加在默认值之后。
+
+`strict` 控制是否额外启用 `typescript-eslint` strict 层独有的规则（`no-useless-constructor`、`typescript/no-dynamic-delete`、`typescript/no-extraneous-class`、`typescript/no-invalid-void-type`、`typescript/no-non-null-asserted-nullish-coalescing`、`typescript/prefer-literal-enum-member`、`typescript/unified-signatures`）。默认 `false`，与 ESLint 侧 `typescript: 'recommended'` 对应；设为 `true` 时与 `typescript: 'strict'` 对应。Oxlint 无法感知 ESLint 档位，两侧需分别声明以保持一致。
 
 未设置 `plugins` 时使用 `OXLINT_DEFAULT_PLUGINS[preset]`。显式 `plugins` 与 Oxlint 原生行为一致，会完整替换默认列表，`[]` 也有效。要追加 plugin，应先展开对应 preset 的默认值：
 
@@ -431,18 +436,18 @@ export default defineConfig(
 
 Flat Config 参数可以是对象或嵌套数组。它们位于内置配置和 Oxlint 派生配置之后，遵循 ESLint 原生级联合并语义。默认 language options 使用最新 ECMAScript、ES modules，以及 Browser 和 Node.js globals。
 
-| 选项               | 类型                                              | 默认     | 说明                                                                    |
-| ------------------ | ------------------------------------------------- | -------- | ----------------------------------------------------------------------- |
-| `ignores`          | `readonly string[]`                               | `[]`     | 追加到默认生成目录之后的全局 ignore                                     |
-| `oxlintConfigFile` | `string \| URL`                                   | 自动查找 | 显式选择用于规则配对的 `.ts` 或 `.mts` Oxlint 配置                      |
-| `react`            | `boolean`                                         | `false`  | 启用 React、JSX parser 选项和 TSX naming fallback                       |
-| `reactHooks`       | `'core' \| 'recommended' \| 'recommended-latest'` | `'core'` | React Hooks 规则档位；仅在 `react: true` 时生效                         |
-| `typescript`       | `boolean \| 'strict'`                             | `true`   | `true` 使用 recommended；`'strict'` 使用 strict；`false` 禁用 TS parser |
+| 选项               | 类型                                              | 默认            | 说明                                                               |
+| ------------------ | ------------------------------------------------- | --------------- | ------------------------------------------------------------------ |
+| `ignores`          | `readonly string[]`                               | `[]`            | 追加到默认生成目录之后的全局 ignore                                |
+| `oxlintConfigFile` | `string \| URL`                                   | 自动查找        | 显式选择用于规则配对的 `.ts` 或 `.mts` Oxlint 配置                 |
+| `react`            | `boolean`                                         | `false`         | 启用 React、JSX parser 选项                                        |
+| `reactHooks`       | `'core' \| 'recommended' \| 'recommended-latest'` | `'core'`        | React Hooks 规则档位；仅在 `react: true` 时生效                    |
+| `typescript`       | `'recommended' \| 'strict'`                       | `'recommended'` | `recommended` 使用 recommended preset；`strict` 使用 strict preset |
 
-`typescript: true` 会启用 typescript-eslint parser、plugin 和非 type-aware 的
-recommended preset，但不会读取 tsconfig 或建立 TypeScript Program。`'strict'` 同样
-只启用非 type-aware 的 strict preset。需要类型信息的 lint rules 应由 Oxlint
-type-aware 执行；`typescript: false` 会禁用整个 TypeScript ESLint 配置。
+`typescript` 控制 typescript-eslint parser、plugin 和非 type-aware preset。配对模式下
+Oxlint 已拥有 strict 独有的规则，两档无可观测差异；纯 ESLint 模式（未安装 Oxlint）下档位决定实际
+启用的规则集。两种模式都不会读取 tsconfig 或建立 TypeScript Program；需要类型信息的 lint rules
+应由 Oxlint type-aware 执行。
 
 ## 共享 Globs
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,6 @@ import { defineConfig } from './dist/index.mjs';
 
 export default defineConfig({
   react: true,
-  typescript: true,
+  typescript: 'recommended',
   ignores: ['dist/**', 'tests/fixtures/**'],
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hongshancapital/eslint-config-hongshan",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Unified ESLint, Oxlint, and formatter configuration",
   "license": "UNLICENSED",
   "author": "Gao Sun",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hongshancapital/eslint-config-hongshan",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Unified ESLint, Oxlint, and formatter configuration",
   "license": "UNLICENSED",
   "author": "Gao Sun",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hongshancapital/eslint-config-hongshan",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Unified ESLint, Oxlint, and formatter configuration",
   "license": "UNLICENSED",
   "author": "Gao Sun",

--- a/src/configs/oxlint-pairing.ts
+++ b/src/configs/oxlint-pairing.ts
@@ -221,6 +221,7 @@ function applyRuntimeRules(
   rules: RuleMap,
   typeAware: boolean,
   metadata: OxlintRuleMetadataMap,
+  registeredRuleNames?: ReadonlySet<string>,
 ): void {
   const disabledRules = rules;
 
@@ -232,9 +233,21 @@ function applyRuntimeRules(
     }
 
     for (const eslintRule of ruleMetadata.eslintRules) {
+      // Only emit disable directives for rules whose ESLint plugin is actually
+      // registered. Setting an unregistered rule to `'off'` is harmless on its
+      // own, but it misleads consumers into thinking the rule is owned by ESLint
+      // and safe to reference in `eslint-disable` comments — which then fail
+      // with "Definition for rule 'X' was not found" in ESLint v10.
+      if (registeredRuleNames && !registeredRuleNames.has(eslintRule)) {
+        continue;
+      }
+
       if (isActive(value)) {
         disabledRules[eslintRule] = 'off';
       } else if (isInactive(value)) {
+        // `eslintRule` is a controlled rule name from the metadata map, not an
+        // arbitrary user key, so dynamic deletion is safe here.
+        // oxlint-disable-next-line typescript/no-dynamic-delete
         delete disabledRules[eslintRule];
       }
     }
@@ -284,6 +297,7 @@ function appendRuleConfigs(
 export function buildDisabledOxlintRulesFromRuntimeConfig(
   config: OxlintRuntimeConfig,
   metadata: OxlintRuleMetadataMap,
+  registeredRuleNames?: ReadonlySet<string>,
 ): FlatConfigArray {
   if (!isObject(config) || !isObject(config.rules)) {
     throw new TypeError('Oxlint --print-config returned an unexpected configuration shape.');
@@ -299,7 +313,7 @@ export function buildDisabledOxlintRulesFromRuntimeConfig(
   const configs: FlatConfigArray = [];
   const rootRules: RuleMap = {};
 
-  applyRuntimeRules(config.rules, rootRules, typeAware, metadata);
+  applyRuntimeRules(config.rules, rootRules, typeAware, metadata, registeredRuleNames);
   appendRuleConfigs(configs, 'oxlint/from-runtime-config', rootRules);
 
   for (const [index, override] of (config.overrides ?? []).entries()) {
@@ -319,7 +333,7 @@ export function buildDisabledOxlintRulesFromRuntimeConfig(
     const overrideRules: RuleMap = {};
 
     if (override.rules) {
-      applyRuntimeRules(override.rules, overrideRules, typeAware, metadata);
+      applyRuntimeRules(override.rules, overrideRules, typeAware, metadata, registeredRuleNames);
     }
 
     appendRuleConfigs(

--- a/src/configs/oxlint-pairing.ts
+++ b/src/configs/oxlint-pairing.ts
@@ -68,7 +68,7 @@ function isObject(value: unknown): value is Record<string, unknown> {
 }
 
 function getSeverity(value: unknown): unknown {
-  return Array.isArray(value) ? value[0] : value;
+  return Array.isArray(value) ? value.at(0) : value;
 }
 
 function isActive(value: unknown): boolean {

--- a/src/configs/react.ts
+++ b/src/configs/react.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'eslint/config';
 
-import { GLOB_SRC, GLOB_TSX } from '../globs';
+import { GLOB_SRC } from '../globs';
 import type { Options } from '../types';
 
 const CORE_REACT_HOOKS_RULES = [
@@ -26,21 +26,6 @@ export async function react(options: Options) {
           ),
         }
       : reactHooks.configs.flat[reactHooksPreset];
-  const reactTypescript =
-    options.typescript === false
-      ? []
-      : defineConfig([
-          {
-            name: '@hongshancapital/eslint-config-hongshan/react-typescript',
-            files: [GLOB_TSX],
-            rules: {
-              '@typescript-eslint/naming-convention': [
-                'error',
-                { selector: 'variable', format: ['camelCase', 'UPPER_CASE', 'PascalCase'] },
-              ],
-            },
-          },
-        ]);
 
   return defineConfig([
     {
@@ -53,6 +38,5 @@ export async function react(options: Options) {
         },
       },
     },
-    ...reactTypescript,
   ]);
 }

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -16,11 +16,7 @@ export function loadTypescriptEslint() {
 }
 
 export async function typescript(options: Options) {
-  const { typescript: tsOption = true } = options;
-
-  if (!tsOption) {
-    return [];
-  }
+  const { typescript: tsOption = 'recommended' } = options;
 
   const { default: tseslint } = await loadTypescriptEslint();
   const isStrict = tsOption === 'strict';
@@ -37,12 +33,6 @@ export async function typescript(options: Options) {
           ecmaVersion: 'latest',
           sourceType: 'module',
         },
-      },
-      rules: {
-        '@typescript-eslint/naming-convention': [
-          'error',
-          { selector: 'variable', format: ['camelCase', 'UPPER_CASE'] },
-        ],
       },
     },
   ]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 
+import js from '@eslint/js';
 import { defineConfig as defineEslintConfig } from 'eslint/config';
 
 import { ignores } from './configs/ignores';
@@ -11,11 +12,12 @@ import { javascript } from './configs/javascript';
 import {
   buildDisabledOxlintRulesFromRuntimeConfig,
   buildOxlintRuleMetadata,
+  type OxlintRuleMetadataMap,
   type OxlintRuntimeConfig,
 } from './configs/oxlint-pairing';
 import { react } from './configs/react';
 import { loadTypescriptEslint, typescript } from './configs/typescript';
-import type { FlatConfigArray, FlatConfigInput, Options } from './types';
+import type { FlatConfig, FlatConfigArray, FlatConfigInput, Options } from './types';
 
 const OXLINT_CONFIG_FILES = ['oxlint.config.ts', 'oxlint.config.mts'];
 const execFileAsync = promisify(execFile);
@@ -27,6 +29,16 @@ function validateOptions(options: Options): void {
 
   if (unknownOption) {
     throw new Error(`Unknown defineConfig option "${unknownOption}"`);
+  }
+
+  if (
+    options.typescript !== undefined &&
+    options.typescript !== 'recommended' &&
+    options.typescript !== 'strict'
+  ) {
+    throw new Error(
+      `Invalid typescript option "${options.typescript}". Use 'recommended' or 'strict'.`,
+    );
   }
 }
 
@@ -122,14 +134,18 @@ async function loadOxlintRuleInventory(oxlintBin: string): Promise<unknown> {
   }
 }
 
-async function buildDisabledOxlintRules(
+type OxlintPairingData = {
+  config: OxlintRuntimeConfig;
+  metadata: OxlintRuleMetadataMap;
+};
+
+async function loadOxlintPairingData(
   configFile: string | URL | undefined,
-  includeTypescriptAliases: boolean,
-): Promise<FlatConfigArray> {
+): Promise<OxlintPairingData | null> {
   const filePath = resolveConfigFile(configFile);
 
   if (!filePath) {
-    return [];
+    return null;
   }
 
   const extension = path.extname(filePath);
@@ -160,14 +176,46 @@ async function buildDisabledOxlintRules(
       `Oxlint --print-config returned invalid JSON for ${filePath}`,
     ),
     loadOxlintRuleInventory(oxlintBin),
-    includeTypescriptAliases ? loadTypescriptEslint() : undefined,
+    loadTypescriptEslint(),
   ]);
-  const typescriptRules = typescriptEslint
-    ? (typescriptEslint.default.plugin as unknown as { rules?: unknown }).rules
-    : undefined;
+  const typescriptRules = (typescriptEslint.default.plugin as unknown as { rules?: unknown }).rules;
   const metadata = buildOxlintRuleMetadata(inventory, typescriptRules);
 
-  return buildDisabledOxlintRulesFromRuntimeConfig(config as OxlintRuntimeConfig, metadata);
+  return { config: config as OxlintRuntimeConfig, metadata };
+}
+
+/**
+ * Collects the names of every rule ESLint can resolve from the assembled configs:
+ * built-in core rules (from `@eslint/js`) plus every rule exposed by a registered
+ * plugin. Used to prevent the Oxlint pairing layer from emitting `'off'` for
+ * rules whose ESLint plugin is not installed (which would mislead consumers into
+ * referencing them in `eslint-disable` comments).
+ */
+function collectRegisteredRuleNames(configs: ReadonlyArray<FlatConfig>): Set<string> {
+  const ruleNames = new Set<string>();
+
+  for (const ruleName of Object.keys(js.configs.all.rules)) {
+    ruleNames.add(ruleName);
+  }
+
+  for (const config of configs) {
+    if (!config.plugins) {
+      continue;
+    }
+
+    for (const [pluginName, plugin] of Object.entries(config.plugins)) {
+      const rules =
+        plugin && typeof plugin === 'object' ? (plugin as { rules?: unknown }).rules : undefined;
+
+      if (rules && typeof rules === 'object') {
+        for (const ruleName of Object.keys(rules as Record<string, unknown>)) {
+          ruleNames.add(`${pluginName}/${ruleName}`);
+        }
+      }
+    }
+  }
+
+  return ruleNames;
 }
 
 export async function defineConfig(
@@ -177,15 +225,30 @@ export async function defineConfig(
   validateOptions(options);
 
   const { ignores: userIgnores = [], oxlintConfigFile } = options;
-  const [disabledOxlintRules, typescriptConfigs, reactConfigs] = await Promise.all([
-    buildDisabledOxlintRules(oxlintConfigFile, options.typescript !== false),
+  const [oxlintData, typescriptConfigs, reactConfigs] = await Promise.all([
+    loadOxlintPairingData(oxlintConfigFile),
     typescript(options),
     react(options),
   ]);
 
+  const jsConfigs = javascript();
+  const registeredRuleNames = collectRegisteredRuleNames([
+    ...jsConfigs,
+    ...typescriptConfigs,
+    ...reactConfigs,
+  ]);
+
+  const disabledOxlintRules = oxlintData
+    ? buildDisabledOxlintRulesFromRuntimeConfig(
+        oxlintData.config,
+        oxlintData.metadata,
+        registeredRuleNames,
+      )
+    : [];
+
   return defineEslintConfig([
     ignores(userIgnores),
-    ...javascript(),
+    ...jsConfigs,
     ...typescriptConfigs,
     ...reactConfigs,
     ...disabledOxlintRules.filter((config) => config.rules !== undefined),

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ function resolveConfigFile(configFile?: string | URL): string | undefined {
     );
   }
 
-  return candidates[0];
+  return candidates.at(0);
 }
 
 async function runOxlintJson(

--- a/src/oxfmt.ts
+++ b/src/oxfmt.ts
@@ -6,7 +6,7 @@ const defaults = {
   printWidth: 100,
   semi: true,
   singleQuote: true,
-  sortImports: true,
+  sortImports: false,
   sortPackageJson: true,
   sortTailwindcss: true,
   tabWidth: 2,

--- a/src/oxlint.ts
+++ b/src/oxlint.ts
@@ -7,6 +7,12 @@ export type OxlintPreset = 'frontend' | 'backend';
 export type OxlintConfigOptions = OxlintConfig & {
   preset: OxlintPreset;
   react?: boolean;
+  /**
+   * 启用 strict 级规则。与 ESLint 侧 `typescript: 'strict'` 对应；
+   * 默认 `false` 对应 `typescript: 'recommended'`。各入口选项互不透传，需分别声明。
+   * @default false
+   */
+  strict?: boolean;
 };
 
 type ConfigField<Key extends keyof OxlintConfig> = NonNullable<OxlintConfig[Key]>;
@@ -92,12 +98,36 @@ const baseRules = {
   'import/no-commonjs': 'error',
   'import/no-cycle': 'error',
   'import/no-duplicates': 'error',
+  'import/no-dynamic-require': 'error',
   'import/no-mutable-exports': 'error',
+  'no-array-constructor': 'error',
+  'no-case-declarations': 'error',
+  'no-empty': 'error',
+  'no-fallthrough': 'error',
+  'no-inner-declarations': 'error',
+  'no-prototype-builtins': 'error',
+  'no-redeclare': 'error',
+  'no-regex-spaces': 'error',
+  'no-unexpected-multiline': 'error',
+  'no-useless-assignment': 'error',
+  'no-var': 'error',
+  'prefer-const': 'error',
+  'prefer-rest-params': 'error',
+  'prefer-spread': 'error',
+  'preserve-caught-error': 'error',
   'typescript/adjacent-overload-signatures': 'error',
+  'typescript/ban-ts-comment': 'error',
   'typescript/consistent-type-imports': 'error',
   'typescript/method-signature-style': ['error', 'property'],
+  'typescript/no-empty-object-type': 'error',
+  'typescript/no-explicit-any': 'error',
   'typescript/no-inferrable-types': 'error',
-  'typescript/no-unused-vars': [
+  'typescript/no-namespace': 'error',
+  'typescript/no-non-null-assertion': 'error',
+  'typescript/no-require-imports': 'error',
+  'typescript/no-unnecessary-type-constraint': 'error',
+  'typescript/no-unsafe-function-type': 'error',
+  'no-unused-vars': [
     'error',
     {
       vars: 'all',
@@ -109,16 +139,39 @@ const baseRules = {
   ],
 } satisfies ConfigField<'rules'>;
 
+/**
+ * strict 级规则：对应 typescript-eslint `strict` preset 独有、且 Oxlint 有等价实现的规则。
+ * 仅在 `strict: true` 时启用，与 ESLint 侧 `typescript: 'strict'` 对齐。
+ */
+const strictRules = {
+  'no-useless-constructor': 'error',
+  'typescript/no-dynamic-delete': 'error',
+  'typescript/no-extraneous-class': 'error',
+  'typescript/no-invalid-void-type': 'error',
+  'typescript/no-non-null-asserted-nullish-coalescing': 'error',
+  'typescript/prefer-literal-enum-member': 'error',
+  'typescript/unified-signatures': 'error',
+} satisfies ConfigField<'rules'>;
+
 const reactRules = {
   'react-hooks/exhaustive-deps': 'off',
   'react-hooks/rules-of-hooks': 'off',
+  'react/jsx-boolean-value': 'error',
+  'react/jsx-curly-brace-presence': 'error',
+  'react/jsx-no-comment-textnodes': 'error',
   'react/jsx-no-literals': 'error',
+  'react/jsx-no-target-blank': 'error',
+  'react/jsx-pascal-case': 'error',
   'react/no-array-index-key': 'error',
+  'react/no-unescaped-entities': 'error',
+  'react/no-unknown-property': 'error',
+  'react/self-closing-comp': 'error',
 } satisfies ConfigField<'rules'>;
 
 export function defineConfig({
   preset,
   react,
+  strict = false,
   categories,
   env,
   ignorePatterns = [],
@@ -151,6 +204,7 @@ export function defineConfig({
     plugins: plugins ?? getDefaultPlugins(preset, reactEnabled),
     rules: {
       ...baseRules,
+      ...(strict ? strictRules : {}),
       ...(reactEnabled ? reactRules : {}),
       ...rules,
     },

--- a/src/oxlint.ts
+++ b/src/oxlint.ts
@@ -93,6 +93,7 @@ const baseRules = {
   ],
   'unicorn/no-array-reverse': ['error', { allowExpressionStatement: false }],
   'unicorn/no-array-sort': ['error', { allowExpressionStatement: false }],
+  'unicorn/prefer-at': ['error', { checkAllIndexAccess: true }],
   'import/export': 'error',
   'import/first': 'error',
   'import/no-commonjs': 'error',

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,10 +30,11 @@ export interface Options {
   reactHooks?: ReactHooksPreset;
 
   /**
-   * TypeScript 规则档位。`true` = 'recommended'；`false` 同时禁用 TypeScript parser。
-   * @default true
+   * TypeScript 规则档位。配对模式下 Oxlint 已拥有 strict 独有的规则，两档无可观测差异；
+   * 纯 ESLint 模式下档位决定实际启用的规则集。
+   * @default 'recommended'
    */
-  typescript?: boolean | 'strict';
+  typescript?: 'recommended' | 'strict';
 }
 
 export type { Linter };

--- a/tests/cli-fixtures.test.ts
+++ b/tests/cli-fixtures.test.ts
@@ -38,6 +38,8 @@ describe('Oxlint CLI fixtures', () => {
     ['javascript/invalid/no-useless-rename.ts', 'eslint(no-useless-rename)'],
     ['javascript/invalid/unused-var.ts', 'eslint(no-unused-vars)'],
     ['typescript/invalid/consistent-type-imports.ts', 'typescript(consistent-type-imports)'],
+    ['typescript/invalid/no-explicit-any.ts', 'typescript(no-explicit-any)'],
+    ['typescript/invalid/no-non-null-assertion.ts', 'typescript(no-non-null-assertion)'],
     ['imports/invalid/duplicate.ts', 'import(no-duplicates)'],
     ['react/invalid/array-index-key.tsx', 'react(no-array-index-key)'],
   ])('reports %s as %s', (file, expectedRule) => {

--- a/tests/fixtures/oxfmt/expected/source.txt
+++ b/tests/fixtures/oxfmt/expected/source.txt
@@ -1,4 +1,4 @@
-import fs from 'node:fs';
 import { join } from 'node:path';
+import fs from 'node:fs';
 const value = { beta: 2, alpha: 1 };
 export { fs, join, value };

--- a/tests/fixtures/oxlint.backend-strict.ts
+++ b/tests/fixtures/oxlint.backend-strict.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from '../../src/oxlint.ts';
+
+export default defineConfig({ preset: 'backend', strict: true });

--- a/tests/fixtures/typescript/invalid/naming-convention.ts
+++ b/tests/fixtures/typescript/invalid/naming-convention.ts
@@ -1,1 +1,0 @@
-export const snake_case = 1;

--- a/tests/fixtures/typescript/invalid/no-non-null-assertion.ts
+++ b/tests/fixtures/typescript/invalid/no-non-null-assertion.ts
@@ -1,0 +1,1 @@
+export const fn = (value?: string): string => value!;

--- a/tests/oxlint-pairing.test.ts
+++ b/tests/oxlint-pairing.test.ts
@@ -145,7 +145,7 @@ describe('Oxlint and ESLint rule ownership', () => {
       new Set(['eqeqeq']),
     );
 
-    const rules = result[0]?.rules;
+    const rules = result.at(0)?.rules;
     expect(rules?.eqeqeq).toBe('off');
     expect(rules?.['react/no-array-index-key']).toBeUndefined();
     expect(rules?.['unicorn/prefer-at']).toBeUndefined();
@@ -164,7 +164,7 @@ describe('Oxlint and ESLint rule ownership', () => {
     const eslint = await createEslint(new URL('./override-off.config.ts', fixturesDirectory));
     const config = await eslint.calculateConfigForFile('example.js');
 
-    expect(config?.rules.eqeqeq?.[0]).toBe(0);
+    expect(config?.rules.eqeqeq?.at(0)).toBe(0);
   });
 
   it('uses Oxlint runtime defaults when deriving ESLint overlap', async () => {
@@ -175,7 +175,7 @@ describe('Oxlint and ESLint rule ownership', () => {
 
     expect(oxlintResult.status).toBe(0);
     expect(oxlintConfig.rules['no-debugger']).toBe('warn');
-    expect(eslintConfig?.rules['no-debugger']?.[0]).toBe(0);
+    expect(eslintConfig?.rules['no-debugger']?.at(0)).toBe(0);
   });
 
   it('uses the installed Oxlint inventory and disables every registered ESLint alias', async () => {
@@ -184,7 +184,7 @@ describe('Oxlint and ESLint rule ownership', () => {
     const eslintConfig = await eslint.calculateConfigForFile('example.js');
 
     // `id-denylist` is a built-in ESLint core rule, so the pairing layer disables it.
-    expect(eslintConfig?.rules['id-denylist']?.[0]).toBe(0);
+    expect(eslintConfig?.rules['id-denylist']?.at(0)).toBe(0);
     // `eslint-plugin-import` / `eslint-plugin-import-x` are not installed in this
     // package, so their rules are skipped instead of being set to `'off'`.
     expect(eslintConfig?.rules['import/no-duplicates']).toBeUndefined();
@@ -198,8 +198,8 @@ describe('Oxlint and ESLint rule ownership', () => {
     const eslintConfig = await eslint.calculateConfigForFile('example.ts');
 
     expect(oxlintConfig.rules['no-unused-vars']).toBe('warn');
-    expect(eslintConfig?.rules['no-unused-vars']?.[0]).toBe(0);
-    expect(eslintConfig?.rules['@typescript-eslint/no-unused-vars']?.[0]).toBe(0);
+    expect(eslintConfig?.rules['no-unused-vars']?.at(0)).toBe(0);
+    expect(eslintConfig?.rules['@typescript-eslint/no-unused-vars']?.at(0)).toBe(0);
   });
 
   it('uses TypeScript ESLint metadata to disable every core-rule extension', async () => {
@@ -218,8 +218,8 @@ describe('Oxlint and ESLint rule ownership', () => {
 
     for (const [eslintRule, typescriptRule] of extendedRules) {
       expect(oxlintConfig.rules[eslintRule]).toBe('deny');
-      expect(eslintConfig?.rules[eslintRule]?.[0]).toBe(0);
-      expect(eslintConfig?.rules[`@typescript-eslint/${typescriptRule}`]?.[0]).toBe(0);
+      expect(eslintConfig?.rules[eslintRule]?.at(0)).toBe(0);
+      expect(eslintConfig?.rules[`@typescript-eslint/${typescriptRule}`]?.at(0)).toBe(0);
     }
   });
 
@@ -230,7 +230,7 @@ describe('Oxlint and ESLint rule ownership', () => {
     const eslintConfig = await eslint.calculateConfigForFile('example.js');
 
     expect(oxlintConfig.rules['no-undef']).toBe('deny');
-    expect(eslintConfig?.rules['no-undef']?.[0]).toBe(0);
+    expect(eslintConfig?.rules['no-undef']?.at(0)).toBe(0);
   });
 
   it('disables type-aware ESLint rules when Oxlint type-aware runtime is enabled', async () => {
@@ -243,7 +243,7 @@ describe('Oxlint and ESLint rule ownership', () => {
 
     expect(oxlintConfig.options?.typeAware).toBe(true);
     expect(oxlintConfig.rules['typescript/await-thenable']).toBe('warn');
-    expect(eslintConfig?.rules['@typescript-eslint/await-thenable']?.[0]).toBe(0);
+    expect(eslintConfig?.rules['@typescript-eslint/await-thenable']?.at(0)).toBe(0);
   });
 
   it('does not disable rules discarded by the Oxlint runtime', async () => {
@@ -302,8 +302,8 @@ describe('Oxlint and ESLint rule ownership', () => {
       'eslint(no-debugger)',
     );
     expect(excludedOxlint.result.status).toBe(0);
-    expect(includedConfig?.rules['no-debugger']?.[0]).toBe(0);
-    expect(excludedConfig?.rules['no-debugger']?.[0]).toBe(2);
+    expect(includedConfig?.rules['no-debugger']?.at(0)).toBe(0);
+    expect(excludedConfig?.rules['no-debugger']?.at(0)).toBe(2);
   });
 
   it.each(['extends-order.config.ts', 'extends-order.config.mts'])(
@@ -319,8 +319,8 @@ describe('Oxlint and ESLint rule ownership', () => {
       expect(result.status).toBe(1);
       expect(codes).toContain('eslint(no-debugger)');
       expect(codes).not.toContain('eslint(no-undef)');
-      expect(config?.rules['no-debugger']?.[0]).toBe(0);
-      expect(config?.rules['no-undef']?.[0]).toBe(2);
+      expect(config?.rules['no-debugger']?.at(0)).toBe(0);
+      expect(config?.rules['no-undef']?.at(0)).toBe(2);
     },
   );
 
@@ -337,8 +337,8 @@ describe('Oxlint and ESLint rule ownership', () => {
       expect(result.status).toBe(1);
       expect(codes).toContain('eslint(eqeqeq)');
       expect(codes).not.toContain('eslint(no-undef)');
-      expect(config?.rules.eqeqeq?.[0]).toBe(0);
-      expect(config?.rules['no-undef']?.[0]).toBe(2);
+      expect(config?.rules.eqeqeq?.at(0)).toBe(0);
+      expect(config?.rules['no-undef']?.at(0)).toBe(2);
     },
   );
 });
@@ -380,7 +380,7 @@ describe('Oxlint rule coverage', () => {
     }
 
     const isActive = (value: unknown) => {
-      const severity = Array.isArray(value) ? value[0] : value;
+      const severity = Array.isArray(value) ? value.at(0) : value;
 
       return ['error', 'warn', 1, 2].includes(severity as never);
     };
@@ -423,7 +423,7 @@ describe('Oxlint rule coverage', () => {
     const oxlintActive = new Set(
       Object.entries(output.rules as Record<string, unknown>)
         .filter(([, value]) => {
-          const severity = Array.isArray(value) ? value[0] : value;
+          const severity = Array.isArray(value) ? value.at(0) : value;
           return ['deny', 'error', 'warn', 1, 2].includes(severity as never);
         })
         .map(([name]) => name),

--- a/tests/oxlint-pairing.test.ts
+++ b/tests/oxlint-pairing.test.ts
@@ -2,11 +2,17 @@ import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import js from '@eslint/js';
 import { ESLint } from 'eslint';
+import tseslint from 'typescript-eslint';
 import { describe, expect, it } from 'vitest';
 
 import { defineConfig, type FlatConfigInput, type Options } from '../src';
-import { buildOxlintRuleMetadata } from '../src/configs/oxlint-pairing';
+import {
+  buildDisabledOxlintRulesFromRuntimeConfig,
+  buildOxlintRuleMetadata,
+  type OxlintRuntimeConfig,
+} from '../src/configs/oxlint-pairing';
 
 const fixturesDirectory = new URL('./fixtures/pairing/', import.meta.url);
 const projectDirectory = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
@@ -49,7 +55,7 @@ function printOxlintConfig(oxlintConfigFile: URL) {
 }
 
 async function createEslint(oxlintConfigFile: URL, ...userConfigs: FlatConfigInput[]) {
-  return createEslintWithOptions(oxlintConfigFile, { typescript: false }, ...userConfigs);
+  return createEslintWithOptions(oxlintConfigFile, { typescript: 'recommended' }, ...userConfigs);
 }
 
 async function createEslintWithOptions(
@@ -66,7 +72,7 @@ async function createEslintWithOptions(
 
 describe('Oxlint and ESLint rule ownership', () => {
   it('auto-discovers the Oxlint config when no file is explicitly provided', async () => {
-    const configs = await defineConfig({ typescript: false });
+    const configs = await defineConfig({ typescript: 'recommended' });
 
     expect(configs.some((config) => config.name === 'oxlint/from-runtime-config')).toBe(true);
   });
@@ -119,11 +125,37 @@ describe('Oxlint and ESLint rule ownership', () => {
     expect(metadata.has('unknown/future-rule')).toBe(false);
   });
 
+  it('skips ESLint rules whose plugin is not registered', () => {
+    const metadata = buildOxlintRuleMetadata([
+      { scope: 'eslint', type_aware: false, value: 'eqeqeq' },
+      { scope: 'react', type_aware: false, value: 'no-array-index-key' },
+      { scope: 'unicorn', type_aware: false, value: 'prefer-at' },
+    ]);
+    const result = buildDisabledOxlintRulesFromRuntimeConfig(
+      {
+        rules: {
+          eqeqeq: 'error',
+          'react/no-array-index-key': 'error',
+          'unicorn/prefer-at': 'error',
+        },
+      } as OxlintRuntimeConfig,
+      metadata,
+      // Only the core `eqeqeq` rule is registered; `eslint-plugin-react` and
+      // `eslint-plugin-unicorn` are not installed.
+      new Set(['eqeqeq']),
+    );
+
+    const rules = result[0]?.rules;
+    expect(rules?.eqeqeq).toBe('off');
+    expect(rules?.['react/no-array-index-key']).toBeUndefined();
+    expect(rules?.['unicorn/prefer-at']).toBeUndefined();
+  });
+
   it('rejects non-TypeScript Oxlint configs', async () => {
     await expect(
       defineConfig({
         oxlintConfigFile: new URL('./unsupported.json', fixturesDirectory),
-        typescript: false,
+        typescript: 'recommended',
       }),
     ).rejects.toThrow('Only .ts and .mts are supported');
   });
@@ -146,20 +178,23 @@ describe('Oxlint and ESLint rule ownership', () => {
     expect(eslintConfig?.rules['no-debugger']?.[0]).toBe(0);
   });
 
-  it('uses the installed Oxlint inventory and disables every ESLint alias', async () => {
+  it('uses the installed Oxlint inventory and disables every registered ESLint alias', async () => {
     const oxlintConfigFile = new URL('./runtime-installed-inventory.config.ts', fixturesDirectory);
     const eslint = await createEslint(oxlintConfigFile);
     const eslintConfig = await eslint.calculateConfigForFile('example.js');
 
+    // `id-denylist` is a built-in ESLint core rule, so the pairing layer disables it.
     expect(eslintConfig?.rules['id-denylist']?.[0]).toBe(0);
-    expect(eslintConfig?.rules['import/no-duplicates']?.[0]).toBe(0);
-    expect(eslintConfig?.rules['import-x/no-duplicates']?.[0]).toBe(0);
+    // `eslint-plugin-import` / `eslint-plugin-import-x` are not installed in this
+    // package, so their rules are skipped instead of being set to `'off'`.
+    expect(eslintConfig?.rules['import/no-duplicates']).toBeUndefined();
+    expect(eslintConfig?.rules['import-x/no-duplicates']).toBeUndefined();
   });
 
   it('disables TypeScript extension aliases for active core Oxlint rules', async () => {
     const oxlintConfigFile = new URL('./runtime-defaults.config.ts', fixturesDirectory);
     const { output: oxlintConfig } = printOxlintConfig(oxlintConfigFile);
-    const eslint = await createEslintWithOptions(oxlintConfigFile, { typescript: true });
+    const eslint = await createEslintWithOptions(oxlintConfigFile, { typescript: 'recommended' });
     const eslintConfig = await eslint.calculateConfigForFile('example.ts');
 
     expect(oxlintConfig.rules['no-unused-vars']).toBe('warn');
@@ -171,7 +206,7 @@ describe('Oxlint and ESLint rule ownership', () => {
     const oxlintConfigFile = new URL('./runtime-typescript-aliases.config.ts', fixturesDirectory);
     const { output: oxlintConfig } = printOxlintConfig(oxlintConfigFile);
     const eslint = await createEslintWithOptions(oxlintConfigFile, {
-      typescript: true,
+      typescript: 'recommended',
     });
     const eslintConfig = await eslint.calculateConfigForFile('typescript/valid/basic.ts');
     const extendedRules = [
@@ -202,7 +237,7 @@ describe('Oxlint and ESLint rule ownership', () => {
     const oxlintConfigFile = new URL('./runtime-type-aware.config.ts', fixturesDirectory);
     const { output: oxlintConfig } = printOxlintConfig(oxlintConfigFile);
     const eslint = await createEslintWithOptions(oxlintConfigFile, {
-      typescript: true,
+      typescript: 'recommended',
     });
     const eslintConfig = await eslint.calculateConfigForFile('typescript/valid/basic.ts');
 
@@ -227,7 +262,7 @@ describe('Oxlint and ESLint rule ownership', () => {
       await expect(
         defineConfig({
           oxlintConfigFile: new URL(configFile, fixturesDirectory),
-          typescript: false,
+          typescript: 'recommended',
         }),
       ).rejects.toThrow('overrides that change plugins');
     },
@@ -306,4 +341,108 @@ describe('Oxlint and ESLint rule ownership', () => {
       expect(config?.rules['no-undef']?.[0]).toBe(2);
     },
   );
+});
+
+/**
+ * Drift guard: ensures every rule that both ESLint (recommended + strict) enables
+ * and Oxlint implements is owned by Oxlint's `baseRules`. When Oxlint gains a new
+ * rule implementation, this test fails and names the rule that can be pushed down.
+ *
+ * `no-dupe-args`, `no-octal`, and `no-undef` are intentionally kept in ESLint:
+ * the first two have no Oxlint equivalent; `no-undef`'s globals semantics differ
+ * between the two linters (Oxlint env is preset-scoped, ESLint injects both
+ * browser and node globals).
+ */
+describe('Oxlint rule coverage', () => {
+  function readOxlintInventory() {
+    const result = spawnSync(process.execPath, [oxlintBin, '--rules', '--format=json'], {
+      cwd: projectDirectory,
+      encoding: 'utf8',
+    });
+
+    return JSON.parse(result.stdout) as Array<{
+      scope: string;
+      value: string;
+      type_aware: boolean;
+    }>;
+  }
+
+  function collectActiveRules(config: unknown) {
+    const configs = Array.isArray(config) ? config : [config];
+    const rules: Record<string, unknown> = {};
+
+    for (const entry of configs) {
+      const entryRules = (entry as { rules?: Record<string, unknown> }).rules;
+
+      if (entryRules) {
+        Object.assign(rules, entryRules);
+      }
+    }
+
+    const isActive = (value: unknown) => {
+      const severity = Array.isArray(value) ? value[0] : value;
+
+      return ['error', 'warn', 1, 2].includes(severity as never);
+    };
+
+    return Object.entries(rules)
+      .filter(([, value]) => isActive(value))
+      .map(([name]) => name);
+  }
+
+  it('owns every ESLint recommended and strict rule that Oxlint implements', () => {
+    const inventory = readOxlintInventory();
+    const metadata = buildOxlintRuleMetadata(
+      inventory,
+      (tseslint.plugin as unknown as { rules: Record<string, unknown> }).rules,
+    );
+
+    // Build the reverse lookup: ESLint rule name → Oxlint rule that owns it.
+    const eslintToOxlint = new Map<string, string>();
+
+    for (const [oxlintRule, meta] of metadata) {
+      if (meta.typeAware) {
+        continue;
+      }
+
+      for (const eslintRule of meta.eslintRules) {
+        eslintToOxlint.set(eslintRule, oxlintRule);
+      }
+    }
+
+    const jsRecommended = collectActiveRules(js.configs.recommended);
+    const tsStrict = collectActiveRules(tseslint.configs.strict);
+    const eslintRules = new Set([...jsRecommended, ...tsStrict]);
+
+    // Use Oxlint's runtime config (`--print-config`), which expands the
+    // `correctness` category and explicit baseRules into the final active set —
+    // exactly what the pairing layer reads. The strict fixture enables the
+    // strict tier so the guard covers the full `tseslint.configs.strict` set.
+    const backendConfigFile = new URL('./fixtures/oxlint.backend-strict.ts', import.meta.url);
+    const { output } = printOxlintConfig(backendConfigFile);
+    const oxlintActive = new Set(
+      Object.entries(output.rules as Record<string, unknown>)
+        .filter(([, value]) => {
+          const severity = Array.isArray(value) ? value[0] : value;
+          return ['deny', 'error', 'warn', 1, 2].includes(severity as never);
+        })
+        .map(([name]) => name),
+    );
+
+    // Rules the pairing layer would disable (ESLint rules with an active Oxlint owner).
+    const wouldDisable = new Set<string>();
+
+    for (const eslintRule of eslintRules) {
+      const oxlintOwner = eslintToOxlint.get(eslintRule);
+
+      if (oxlintOwner && oxlintActive.has(oxlintOwner)) {
+        wouldDisable.add(eslintRule);
+      }
+    }
+
+    // Residual: ESLint rules with no Oxlint owner, or whose owner is not enabled.
+    const residual = [...eslintRules].filter((rule) => !wouldDisable.has(rule)).toSorted();
+
+    expect(residual).toEqual(['no-dupe-args', 'no-octal', 'no-undef']);
+  });
 });

--- a/tests/run-fixtures.test.ts
+++ b/tests/run-fixtures.test.ts
@@ -72,8 +72,6 @@ describe('ESLint config fixtures', () => {
   it.each([
     ['javascript/invalid/no-restricted-syntax.ts', 'no-restricted-syntax'],
     ['javascript/invalid/no-secrets.ts', 'no-secrets/no-secrets'],
-    ['typescript/invalid/naming-convention.ts', '@typescript-eslint/naming-convention'],
-    ['typescript/invalid/no-explicit-any.ts', '@typescript-eslint/no-explicit-any'],
   ])('%s is still checked by %s', async (file, expectedRule) => {
     const [result] = await frontendEslint.lintFiles(path.join(fixturesDir, file));
 
@@ -88,7 +86,7 @@ describe('ESLint config composition', () => {
 
     try {
       process.chdir(fixturesDir);
-      config = await defineConfig({ typescript: false });
+      config = await defineConfig({ typescript: 'recommended' });
     } finally {
       process.chdir(originalCwd);
     }
@@ -111,13 +109,13 @@ describe('ESLint config composition', () => {
     const eslint = await createEslint({ oxlintConfigFile: backendOxlintConfigFile });
     const config = await eslint.calculateConfigForFile('example.js');
 
-    expect(config?.rules['@typescript-eslint/no-explicit-any']).toBeUndefined();
+    expect(config?.rules['@typescript-eslint/array-type']).toBeUndefined();
   });
 
   it('does not inherit ignores from the paired Oxlint config', async () => {
     const eslint = await createEslint({
       oxlintConfigFile: frontendOxlintConfigFile,
-      typescript: false,
+      typescript: 'recommended',
     });
     const [result] = await eslint.lintText('const values = []; values.unshift(1);', {
       filePath: 'oxlint-only/example.js',
@@ -129,11 +127,11 @@ describe('ESLint config composition', () => {
     expect(result?.messages.some((message) => message.ruleId === null)).toBe(false);
   });
 
-  it('supports React without TypeScript', async () => {
+  it('does not apply TypeScript rules to JSX', async () => {
     const eslint = await createEslint({
       oxlintConfigFile: frontendOxlintConfigFile,
       react: true,
-      typescript: false,
+      typescript: 'recommended',
     });
     const [result] = await eslint.lintText(
       'export default function Component() { return <div />; }',
@@ -143,11 +141,11 @@ describe('ESLint config composition', () => {
     expect(result?.fatalErrorCount).toBe(0);
   });
 
-  it('does not reference TypeScript plugin rules for JSX in a .tsx file when disabled', async () => {
+  it('parses TSX without fatal errors', async () => {
     const eslint = await createEslint({
       oxlintConfigFile: frontendOxlintConfigFile,
       react: true,
-      typescript: false,
+      typescript: 'recommended',
     });
     const [result] = await eslint.lintText(
       'export default function Component() { return <div />; }',
@@ -159,7 +157,7 @@ describe('ESLint config composition', () => {
 
   it('merges default and user globals using native flat config semantics', async () => {
     const eslint = await createEslint(
-      { oxlintConfigFile: backendOxlintConfigFile, typescript: false },
+      { oxlintConfigFile: backendOxlintConfigFile, typescript: 'recommended' },
       [{ languageOptions: { globals: { process: 'off', testGlobal: 'readonly' } } }],
     );
     const config = await eslint.calculateConfigForFile('example.js');
@@ -206,7 +204,7 @@ describe('ESLint config composition', () => {
     const eslint = await createEslint({
       oxlintConfigFile: frontendOxlintConfigFile,
       react: true,
-      typescript: false,
+      typescript: 'recommended',
     });
     const config = await eslint.calculateConfigForFile('component.jsx');
 
@@ -224,7 +222,7 @@ describe('ESLint config composition', () => {
       oxlintConfigFile: frontendOxlintConfigFile,
       react: true,
       reactHooks,
-      typescript: false,
+      typescript: 'recommended',
     });
     const config = await eslint.calculateConfigForFile('component.jsx');
 
@@ -249,7 +247,7 @@ describe('ESLint config composition', () => {
     async (filePath) => {
       const eslint = await createEslint({
         oxlintConfigFile: backendOxlintConfigFile,
-        typescript: false,
+        typescript: 'recommended',
       });
       const [result] = await eslint.lintText('const values = []; values.unshift(1);', {
         filePath,
@@ -264,7 +262,7 @@ describe('ESLint config composition', () => {
   it('allows references to mutating methods', async () => {
     const eslint = await createEslint({
       oxlintConfigFile: backendOxlintConfigFile,
-      typescript: false,
+      typescript: 'recommended',
     });
     const [result] = await eslint.lintText(
       'const values = [1]; const callback = Array.of(values.pop); export { callback };',
@@ -278,7 +276,7 @@ describe('ESLint config composition', () => {
 
   it('does not apply JavaScript rules to user-added non-source languages', async () => {
     const eslint = await createEslint(
-      { oxlintConfigFile: backendOxlintConfigFile, typescript: false },
+      { oxlintConfigFile: backendOxlintConfigFile, typescript: 'recommended' },
       { files: ['**/*.json'] },
     );
     const config = await eslint.calculateConfigForFile('data.json');
@@ -290,6 +288,21 @@ describe('ESLint config composition', () => {
     const eslint = await createEslint({ oxlintConfigFile: backendOxlintConfigFile });
     const config = await eslint.calculateConfigForFile('example.js');
 
+    expect(config?.rules.eqeqeq?.[0]).toBe(0);
+    expect(config?.rules['no-console']?.[0]).toBe(0);
+  });
+
+  it('does not disable rules for unregistered ESLint plugins', async () => {
+    const config = await frontendEslint.calculateConfigForFile('example.tsx');
+
+    // `react/no-array-index-key` is active in the frontend Oxlint preset, but
+    // `eslint-plugin-react` is not installed in this package, so the pairing
+    // layer must not emit a misleading `'off'` directive for it.
+    expect(config?.rules['react/no-array-index-key']).toBeUndefined();
+    // `unicorn/no-array-reverse` is active in the Oxlint config, but
+    // `eslint-plugin-unicorn` is not installed.
+    expect(config?.rules['unicorn/no-array-reverse']).toBeUndefined();
+    // Core rules that overlap with Oxlint are still disabled.
     expect(config?.rules.eqeqeq?.[0]).toBe(0);
     expect(config?.rules['no-console']?.[0]).toBe(0);
   });

--- a/tests/run-fixtures.test.ts
+++ b/tests/run-fixtures.test.ts
@@ -208,8 +208,8 @@ describe('ESLint config composition', () => {
     });
     const config = await eslint.calculateConfigForFile('component.jsx');
 
-    expect(config?.rules['react-hooks/rules-of-hooks']?.[0]).toBe(2);
-    expect(config?.rules['react-hooks/exhaustive-deps']?.[0]).toBe(1);
+    expect(config?.rules['react-hooks/rules-of-hooks']?.at(0)).toBe(2);
+    expect(config?.rules['react-hooks/exhaustive-deps']?.at(0)).toBe(1);
     expect(config?.rules['react-hooks/static-components']).toBeUndefined();
     expect(config?.rules['react-hooks/use-memo']).toBeUndefined();
   });
@@ -226,8 +226,8 @@ describe('ESLint config composition', () => {
     });
     const config = await eslint.calculateConfigForFile('component.jsx');
 
-    expect(config?.rules['react-hooks/static-components']?.[0]).toBe(2);
-    expect(config?.rules['react-hooks/void-use-memo']?.[0]).toBe(voidUseMemoSeverity);
+    expect(config?.rules['react-hooks/static-components']?.at(0)).toBe(2);
+    expect(config?.rules['react-hooks/void-use-memo']?.at(0)).toBe(voidUseMemoSeverity);
   });
 
   it('keeps inactive Nursery fallback in ESLint', async () => {
@@ -237,9 +237,9 @@ describe('ESLint config composition', () => {
     const config = await eslint.calculateConfigForFile('typescript/valid/basic.ts');
     const javascriptConfig = await eslint.calculateConfigForFile('example.js');
 
-    expect(javascriptConfig?.rules['no-undef']?.[0]).toBe(2);
-    expect(config?.rules['no-unreachable']?.[0]).toBe(0);
-    expect(config?.rules['@typescript-eslint/no-unused-vars']?.[0]).toBe(0);
+    expect(javascriptConfig?.rules['no-undef']?.at(0)).toBe(2);
+    expect(config?.rules['no-unreachable']?.at(0)).toBe(0);
+    expect(config?.rules['@typescript-eslint/no-unused-vars']?.at(0)).toBe(0);
   });
 
   it.each(['eslint.config.js', 'example.test.js', 'scripts/build.js'])(
@@ -288,8 +288,8 @@ describe('ESLint config composition', () => {
     const eslint = await createEslint({ oxlintConfigFile: backendOxlintConfigFile });
     const config = await eslint.calculateConfigForFile('example.js');
 
-    expect(config?.rules.eqeqeq?.[0]).toBe(0);
-    expect(config?.rules['no-console']?.[0]).toBe(0);
+    expect(config?.rules.eqeqeq?.at(0)).toBe(0);
+    expect(config?.rules['no-console']?.at(0)).toBe(0);
   });
 
   it('does not disable rules for unregistered ESLint plugins', async () => {
@@ -303,8 +303,8 @@ describe('ESLint config composition', () => {
     // `eslint-plugin-unicorn` is not installed.
     expect(config?.rules['unicorn/no-array-reverse']).toBeUndefined();
     // Core rules that overlap with Oxlint are still disabled.
-    expect(config?.rules.eqeqeq?.[0]).toBe(0);
-    expect(config?.rules['no-console']?.[0]).toBe(0);
+    expect(config?.rules.eqeqeq?.at(0)).toBe(0);
+    expect(config?.rules['no-console']?.at(0)).toBe(0);
   });
 });
 
@@ -319,7 +319,7 @@ describe('Oxlint config', () => {
     expect(backend.plugins).not.toContain('react');
     expect(backend.env).toMatchObject({ node: true });
     expect(frontend.categories).toEqual({ correctness: 'error' });
-    expect(frontend.overrides?.[0]?.files).toEqual([GLOB_JSX, GLOB_TSX]);
+    expect(frontend.overrides?.at(0)?.files).toEqual([GLOB_JSX, GLOB_TSX]);
   });
 
   it('lets explicit plugins replace the preset defaults', () => {

--- a/tests/run-fixtures.test.ts
+++ b/tests/run-fixtures.test.ts
@@ -391,7 +391,7 @@ describe('Oxfmt config', () => {
     expect(config).toMatchObject({
       printWidth: 100,
       singleQuote: true,
-      sortImports: true,
+      sortImports: false,
       sortPackageJson: true,
       sortTailwindcss: true,
     });


### PR DESCRIPTION
## 变更内容

### Oxlint 规则集扩充
- **新增大量显式规则**：覆盖 `eslint:recommended` 和 `typescript-eslint` recommended 层中所有在 Oxlint 有等价实现的规则（`no-var`、`prefer-const`、`no-empty`、`no-fallthrough`、`typescript/no-explicit-any`、`typescript/no-non-null-assertion` 等），以及 `unicorn/prefer-at`（强制使用 `.at()` 访问数组索引）。
- **新增 strict 规则层**（`src/oxlint.ts`）：对应 typescript-eslint `strict` preset 独有、且 Oxlint 有等价实现的 7 条规则（`no-useless-constructor`、`typescript/no-dynamic-delete` 等），通过 `strict: true` 启用。
- **新增 React 规则**：补充 `react/jsx-boolean-value`、`react/jsx-curly-brace-presence`、`react/no-unescaped-entities` 等 8 条规则。

### ESLint ↔ Oxlint 配对增强
- **仅关闭已注册插件的规则**：`applyRuntimeRules` 新增 `registeredRuleNames` 参数，通过 `collectRegisteredRuleNames` 收集 `@eslint/js` 核心规则及所有已注册插件的规则名，避免对未安装插件输出 `'off'`，防止消费者误用 `eslint-disable` 注释触发 ESLint v10 "Definition for rule not found"。
- **TypeScript ESLint 始终参与配对**：移除 `includeTypescriptAliases` 开关，typescript-eslint plugin 规则常驻 metadata 构建。

### TypeScript 档位重构
- **`typescript` 选项改为 `recommended | strict` 字符串**：`true`/`false`/`'strict'` → `'recommended'`/`'strict'`，移除布尔语义。配对模式下 Oxlint 已拥有 strict 独有规则，两档无可观测差异；纯 ESLint 模式下档位决定实际规则集。
- **移除 `@typescript-eslint/naming-convention` 自定义规则**：React TSX 与 TS 的 naming-convention 规则块删除，统一交由默认 preset 管理。

## 变更原因

1. **配对层遗漏 recommended 规则**：Oxlint 显式规则未完整覆盖 ESLint/TS-ESLint recommended 层，导致两套工具重复报错或 ESLint 侧规则未被关闭。
2. **未注册规则产生误导**：`eslint-disable` 注释引用未注册插件规则在 ESLint v10 报错，需在配对层过滤。
3. **布尔档位语义模糊**：`typescript: true/false` 无法清晰表达 recommended/strict 两档，且配对模式下 strict 与 recommended 实际等价，重构为字符串枚举更准确。

## 验证方式

- 运行 `pnpm test`，4 个测试文件 / 88 个测试全部通过（含新增 `oxlint.backend-strict.ts` fixture、`no-non-null-assertion` fixture、配对层未注册规则过滤测试）。
- 运行 `pnpm typecheck`，TypeScript 编译通过。
- 运行 `pnpm lint`，Oxlint 与 ESLint 双工具均无报错。

## 风险与注意事项

- **Breaking Change：`typescript` 选项类型变更**。`true`/`false`/`'strict'` → `'recommended'`/`'strict'`。升级时需将 `typescript: true` 改为 `typescript: 'recommended'`，`typescript: false` 不再支持（原禁用 TS parser 的能力移除）。`eslint.config.js` 已同步更新。
- **移除 `@typescript-eslint/naming-convention` 规则**：此前对 TSX/TS 变量命名的 `camelCase`/`UPPER_CASE` 强制不再生效，改由 typescript-eslint 默认 preset 接管。
- **版本升至 2.3.1**。
